### PR TITLE
Syncing main branch with development after completed changes to runtime and rendering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ pub mod rendering;
 // flatten
 pub use materials::Material;
 pub use objects::ObjectList;
-pub use rendering::Renderer;
 pub use rendering::Camera;
 pub use rendering::CameraBuilder;
-
+pub use rendering::Renderer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod materials;
 pub mod math;
 pub mod objects;
 pub mod rendering;
+pub mod runtime;
 
 // flatten
 pub use materials::Material;
@@ -10,3 +11,4 @@ pub use objects::ObjectList;
 pub use rendering::Camera;
 pub use rendering::CameraBuilder;
 pub use rendering::Renderer;
+pub use runtime::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn setup() -> (Camera, ObjectList, usize, usize) {
     let objects = make_cube_array();
 
     let camera = CameraBuilder::new()
-        .resolution(1024, 576)
+        .resolution(4095, 2304)
         .vfov(90.0)
         .target(6.0, 0.0, 6.0)
         .position(8.0, 8.0, 8.0)
@@ -43,15 +43,7 @@ fn main() -> std::io::Result<()> {
     let mut output = File::create(output_path)?;
 
     let (camera, objects, thread_count, batch_count) = setup();
-
-    let renderer = WorkerRenderer::new(
-        camera,
-        objects,
-        thread_count,
-        batch_count
-    );
-
-//    let renderer = Renderer::new(camera, objects, thread_count);
+    let renderer = Renderer::new(camera, objects, thread_count, batch_count);
     let image = renderer.render();
 
     let output_text = format!("{image}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn make_cube_array() -> ObjectList {
         for j in 0..4 {
             let (cx, cy) = (3.0 * i as f64, 3.0 * j as f64);
             let mat = Material::new_metal(0.5, 0.5, 0.7, 0.0);
-            objects.add_sphere(1.0, cx, 0.5, cy, mat);
+            objects.add_cube(1.0, cx, 0.5, cy, mat);
         }
     }
     let ground = Material::new_diffuse(0.5, 0.5, 0.5);
@@ -30,9 +30,10 @@ fn setup() -> (Camera, ObjectList, usize) {
         .target(6.0, 0.0, 6.0)
         .position(8.0, 8.0, 8.0)
         .upward(0.0, 1.0, 0.0)
-        .samples(10)
+        .samples(100)
         .max_depth(10)
         .build();
+
     (camera, objects, 32)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn setup() -> (Camera, ObjectList, usize, usize) {
         .target(6.0, 0.0, 6.0)
         .position(8.0, 8.0, 8.0)
         .upward(0.0, 1.0, 0.0)
-        .samples(1)
+        .samples(100)
         .max_depth(10)
         .build();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
+use lumen::rendering::*;
 use lumen::Material;
 use lumen::ObjectList;
-use lumen::rendering::*;
 
 fn setup() -> (Camera, ObjectList, usize) {
     let ground = Material::new_diffuse(0.5, 0.5, 0.5);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn make_cube_array() -> ObjectList {
     objects
 }
 
-fn setup() -> (Camera, ObjectList, usize) {
+fn setup() -> (Camera, ObjectList, usize, usize) {
     let objects = make_cube_array();
 
     let camera = CameraBuilder::new()
@@ -34,7 +34,7 @@ fn setup() -> (Camera, ObjectList, usize) {
         .max_depth(10)
         .build();
 
-    (camera, objects, 32)
+    (camera, objects, 8, 256)
 }
 
 fn main() -> std::io::Result<()> {
@@ -42,8 +42,13 @@ fn main() -> std::io::Result<()> {
     let output_path = PathBuf::from(args[1].as_str());
     let mut output = File::create(output_path)?;
 
-    let (camera, objects, thread_count) = setup();
-    let renderer = Renderer::new(camera, objects, thread_count);
+    let (camera, objects, thread_count, batch_count) = setup();
+    let renderer = WorkerRenderer::new(
+        camera,
+        objects,
+        thread_count,
+        batch_count
+    );
     let image = renderer.render();
 
     let output_text = format!("{image}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn setup() -> (Camera, ObjectList, usize, usize) {
         .target(6.0, 0.0, 6.0)
         .position(8.0, 8.0, 8.0)
         .upward(0.0, 1.0, 0.0)
-        .samples(100)
+        .samples(1)
         .max_depth(10)
         .build();
 
@@ -43,12 +43,15 @@ fn main() -> std::io::Result<()> {
     let mut output = File::create(output_path)?;
 
     let (camera, objects, thread_count, batch_count) = setup();
+
     let renderer = WorkerRenderer::new(
         camera,
         objects,
         thread_count,
         batch_count
     );
+
+//    let renderer = Renderer::new(camera, objects, thread_count);
     let image = renderer.render();
 
     let output_text = format!("{image}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn setup() -> (Camera, ObjectList, usize, usize) {
         .target(6.0, 0.0, 6.0)
         .position(8.0, 8.0, 8.0)
         .upward(0.0, 1.0, 0.0)
-        .samples(100)
+        .samples(1)
         .max_depth(10)
         .build();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,30 +7,33 @@ use lumen::rendering::*;
 use lumen::Material;
 use lumen::ObjectList;
 
-fn setup() -> (Camera, ObjectList, usize) {
-    let ground = Material::new_diffuse(0.5, 0.5, 0.5);
-    let mat1 = Material::new_dielectric(1.50);
-    let mat2 = Material::new_diffuse(0.2, 0.5, 0.7);
-    let mat3 = Material::new_metal(0.2, 0.7, 0.5, 0.0);
-    let green = Material::new_diffuse(0.2, 0.8, 0.2);
-
+fn make_cube_array() -> ObjectList {
     let mut objects = ObjectList::new();
+    for i in 0..4 {
+        for j in 0..4 {
+            let (cx, cy) = (3.0 * i as f64, 3.0 * j as f64);
+            let mat = Material::new_metal(0.5, 0.5, 0.7, 0.0);
+            objects.add_sphere(1.0, cx, 0.5, cy, mat);
+        }
+    }
+    let ground = Material::new_diffuse(0.5, 0.5, 0.5);
     objects.add_sphere(1000.0, 0.0, -1000.0, 0.0, ground);
-    objects.add_sphere(1.0, 0.0, 1.0, 0.0, mat1);
-    objects.add_sphere(1.0, -2.0, 1.0, 0.0, mat2);
-    objects.add_sphere(1.0, 2.0, 1.0, 0.0, mat3);
-    objects.add_cube(1.0, 2.0, 1.0, 1.0, green);
+    objects
+}
+
+fn setup() -> (Camera, ObjectList, usize) {
+    let objects = make_cube_array();
 
     let camera = CameraBuilder::new()
         .resolution(1024, 576)
         .vfov(90.0)
-        .target(0.0, 0.0, -1.0)
-        .position(3.0, 2.0, 3.0)
+        .target(6.0, 0.0, 6.0)
+        .position(8.0, 8.0, 8.0)
         .upward(0.0, 1.0, 0.0)
         .samples(10)
         .max_depth(10)
         .build();
-    (camera, objects, 8)
+    (camera, objects, 32)
 }
 
 fn main() -> std::io::Result<()> {

--- a/src/materials/materials.rs
+++ b/src/materials/materials.rs
@@ -85,8 +85,8 @@ impl Scatter for Metal {
         scattered: &mut Ray,
     ) -> bool {
         let mut reflected = Vec3::reflect(r.direction, record.normal);
-        reflected = Vec3::unit_vector(reflected)
-            + self.fuzz * Vec3::random_vector();
+        reflected =
+            Vec3::unit_vector(reflected) + self.fuzz * Vec3::random_vector();
         *scattered = Ray::new(record.point, reflected);
         *attenuation = self.albedo.clone();
         return (scattered.direction * record.normal) > 0.0;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,8 +1,10 @@
 // modules
 pub mod ray;
 pub mod vec3;
+pub mod util;
 
 // flatten
 pub use ray::Interval;
 pub use ray::Ray;
 pub use vec3::Vec3;
+pub use util::lerp;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,10 +1,10 @@
 // modules
 pub mod ray;
-pub mod vec3;
 pub mod util;
+pub mod vec3;
 
 // flatten
 pub use ray::Interval;
 pub use ray::Ray;
-pub use vec3::Vec3;
 pub use util::lerp;
+pub use vec3::Vec3;

--- a/src/math/util.rs
+++ b/src/math/util.rs
@@ -1,0 +1,7 @@
+use super::*;
+
+pub fn lerp(r: &Ray, color_from: Vec3, color_to: Vec3) -> Vec3 {
+    let unit_direction = Vec3::unit_vector(r.direction);
+    let a = 0.5 * (unit_direction.y + 1.0);
+    return (1.0 - a) * color_from + a * color_to;
+}

--- a/src/objects/cube.rs
+++ b/src/objects/cube.rs
@@ -23,7 +23,12 @@ impl Cube {
 }
 
 impl Physical for Cube {
+    fn get_verticies(&self) -> Vec<Vec3> {
+        todo!()
+    }
+    
     fn hit(&self, r: &Ray, rt: &Interval, record: &mut HitRecord) -> bool {
+        // todo - move this to get_verticies, simplify computation as well
         let furthest_corner = Vec3 {
             x: self.center.x + 1.0,
             y: self.center.y + 1.0,

--- a/src/objects/cube.rs
+++ b/src/objects/cube.rs
@@ -1,8 +1,8 @@
 use crate::materials::Material;
 use crate::math::*;
 
-use super::Physical;
 use super::HitRecord;
+use super::Physical;
 use super::Quad;
 
 #[derive(Debug, Clone)]

--- a/src/objects/cube.rs
+++ b/src/objects/cube.rs
@@ -10,69 +10,66 @@ pub struct Cube {
     pub length: f64,
     pub center: Vec3,
     pub mat: Material,
+    sides: Vec<Quad>,
 }
 
 impl Cube {
     pub fn new(length: f64, center: Vec3, mat: Material) -> Self {
+        let far_corner =
+            Vec3::new(center.x + length, center.y + length, center.z + length);
+        let mut sides: Vec<Quad> = Vec::with_capacity(6);
+        sides.push(Quad::new(
+            center,
+            Vec3::new(0.0, length, 0.0),
+            Vec3::new(0.0, 0.0, length),
+            mat,
+        ));
+        sides.push(Quad::new(
+            center,
+            Vec3::new(0.0, length, 0.0),
+            Vec3::new(length, 0.0, 0.0),
+            mat,
+        ));
+        sides.push(Quad::new(
+            center,
+            Vec3::new(length, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, length),
+            mat,
+        ));
+        sides.push(Quad::new(
+            far_corner,
+            Vec3::new(0.0, -length, 0.0),
+            Vec3::new(0.0, 0.0, -length),
+            mat,
+        ));
+        sides.push(Quad::new(
+            far_corner,
+            Vec3::new(0.0, -length, 0.0),
+            Vec3::new(-length, 0.0, 0.0),
+            mat,
+        ));
+        sides.push(Quad::new(
+            far_corner,
+            Vec3::new(-length, 0.0, 0.0),
+            Vec3::new(0.0, 0.0, -length),
+            mat,
+        ));
         Self {
             length,
             center,
             mat,
+            sides,
         }
+    }
+
+    fn get_quads(&self) -> &Vec<Quad> {
+        &self.sides
     }
 }
 
 impl Physical for Cube {
-    fn get_verticies(&self) -> Vec<Vec3> {
-        todo!()
-    }
-    
     fn hit(&self, r: &Ray, rt: &Interval, record: &mut HitRecord) -> bool {
-        // todo - move this to get_verticies, simplify computation as well
-        let furthest_corner = Vec3 {
-            x: self.center.x + 1.0,
-            y: self.center.y + 1.0,
-            z: self.center.z + 1.0,
-        };
-        let q1 = Quad::new(
-            self.center,
-            Vec3::new(0.0, 1.0, 0.0),
-            Vec3::new(0.0, 0.0, 1.0),
-            self.mat,
-        );
-        let q2 = Quad::new(
-            self.center,
-            Vec3::new(0.0, 1.0, 0.0),
-            Vec3::new(1.0, 0.0, 0.0),
-            self.mat,
-        );
-        let q3 = Quad::new(
-            self.center,
-            Vec3::new(1.0, 0.0, 0.0),
-            Vec3::new(0.0, 0.0, 1.0),
-            self.mat,
-        );
-        let q4 = Quad::new(
-            furthest_corner,
-            Vec3::new(0.0, -1.0, 0.0),
-            Vec3::new(0.0, 0.0, -1.0),
-            self.mat,
-        );
-        let q5 = Quad::new(
-            furthest_corner,
-            Vec3::new(0.0, -1.0, 0.0),
-            Vec3::new(-1.0, 0.0, 0.0),
-            self.mat,
-        );
-        let q6 = Quad::new(
-            furthest_corner,
-            Vec3::new(-1.0, 0.0, 0.0),
-            Vec3::new(0.0, 0.0, -1.0),
-            self.mat,
-        );
-
-        let quads = vec![q1, q2, q3, q4, q5, q6];
-
+        let quads = self.get_quads();
         let mut tmp = HitRecord::default();
         let mut hit = false;
         let mut closest_q = 0;

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -3,9 +3,9 @@ pub mod record;
 
 pub mod objects;
 
-pub mod sphere;
 pub mod cube;
 pub mod quad;
+pub mod sphere;
 
 // flatten
 pub use record::HitRecord;
@@ -13,6 +13,6 @@ pub use record::HitRecord;
 pub use objects::ObjectList;
 pub use objects::Physical;
 
-pub use sphere::Sphere;
 pub use cube::Cube;
 pub use quad::Quad;
+pub use sphere::Sphere;

--- a/src/objects/objects.rs
+++ b/src/objects/objects.rs
@@ -11,7 +11,9 @@ pub struct ObjectList {
 impl ObjectList {
     #[allow(dead_code)]
     pub fn new() -> Self {
-        ObjectList { objects: Vec::new() }
+        ObjectList {
+            objects: Vec::new(),
+        }
     }
 
     pub fn add_sphere(

--- a/src/objects/quad.rs
+++ b/src/objects/quad.rs
@@ -1,8 +1,8 @@
 use crate::materials::Material;
 use crate::math::*;
 
-use super::Physical;
 use super::HitRecord;
+use super::Physical;
 
 #[derive(Debug, Clone)]
 pub struct Quad {

--- a/src/objects/sphere.rs
+++ b/src/objects/sphere.rs
@@ -1,8 +1,8 @@
 use crate::materials::Material;
 use crate::math::*;
 
-use super::Physical;
 use super::HitRecord;
+use super::Physical;
 
 #[derive(Debug, Clone)]
 pub struct Sphere {

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -11,5 +11,3 @@ pub use camera::Camera;
 pub use camera::CameraBuilder;
 
 pub use renderer::Renderer;
-
-pub use renderer::WorkerRenderer;

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -11,3 +11,5 @@ pub use camera::Camera;
 pub use camera::CameraBuilder;
 
 pub use renderer::Renderer;
+
+pub use renderer::WorkerRenderer;

--- a/src/rendering/mod.rs
+++ b/src/rendering/mod.rs
@@ -1,6 +1,6 @@
 // modules
-pub mod image;
 pub mod camera;
+pub mod image;
 pub mod renderer;
 
 // flatten
@@ -11,5 +11,3 @@ pub use camera::Camera;
 pub use camera::CameraBuilder;
 
 pub use renderer::Renderer;
-
-

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -96,22 +96,17 @@ impl ChunkRenderer {
         (hit, record)
     }
 
-    // todo - update this function to be generic over two paramaters,
-    // move out into the math module.
-    fn lerp(r: &Ray) -> Vec3 {
-        let unit_direction = Vec3::unit_vector(r.direction);
-        let a = 0.5 * (unit_direction.y + 1.0);
-        return (1.0 - a) * Vec3::new(0.5, 0.7, 1.0)
-            + a * Vec3::new(1.0, 1.0, 1.0);
-    }
-
     fn cast_ray(&self, r: &Ray, depth: usize) -> Vec3 {
         if depth <= 0 {
             return Vec3::default();
         }
         let (hit, rec) = self.check_hit(&r);
         if !hit {
-            return Self::lerp(&r);
+            return lerp(
+                &r,
+                Vec3::new(0.5, 0.7, 1.0),
+                Vec3::new(1.0, 1.0, 1.0),
+            );
         }
         let (mut at, mut scattered) = (Vec3::default(), Ray::default());
         if let Some(mat) = rec.mat {

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -68,13 +68,16 @@ impl ChunkRenderer {
         col_start: usize,
         col_end: usize,
     ) -> Vec<(f64, f64)> {
+        // todo - fix this function and reduce complexity
         (row_start..row_end)
             .flat_map(|r| {
                 (col_start..col_end).map(move |c| (r as f64, c as f64))
             })
             .collect::<Vec<_>>()
     }
-
+    
+    // the indicies function is probably an unnecessary perf cost.
+    // Consider removing it and moving it into `get_rays`
     fn get_rays(&self, indicies: &[(f64, f64)], rays: &mut [Ray]) {
         let pixel_count = indicies.len();
         let default_direction = self.cam.pixel_origin - self.cam.position;
@@ -100,6 +103,8 @@ impl ChunkRenderer {
         (hit, record)
     }
 
+    // todo - update this function to be generic over two paramaters,
+    // move out into the math module.
     fn lerp(r: &Ray) -> Vec3 {
         let unit_direction = Vec3::unit_vector(r.direction);
         let a = 0.5 * (unit_direction.y + 1.0);

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -5,6 +5,9 @@ use crate::materials::Scatter;
 use crate::math::*;
 use crate::objects::*;
 
+use crate::runtime::Operation;
+use crate::runtime::Runtime;
+
 use super::image::*;
 use super::Camera;
 
@@ -12,6 +15,128 @@ pub struct Renderer {
     camera: Arc<Camera>,
     objects: Arc<ObjectList>,
     thread_count: usize,
+}
+
+pub struct ChunkRenderer {
+    objs: Arc<ObjectList>,
+    cam: Arc<Camera>,
+}
+
+pub struct PixelRenderer {
+    objs: Arc<ObjectList>,
+    cam: Arc<Camera>,
+}
+
+pub struct WorkerRenderer {
+    camera: Arc<Camera>,
+    objects: Arc<ObjectList>,
+    thread_count: usize,
+    batch_count: usize,
+}
+
+impl PixelRenderer {
+    pub fn new(objects: &Arc<ObjectList>, camera: &Arc<Camera>) -> Self {
+        Self {
+            objs: Arc::clone(objects),
+            cam: Arc::clone(camera),
+        }
+    }
+
+    fn get_ray(&self, i: usize, j: usize) -> Ray {
+        let default_direction = self.cam.pixel_origin - self.cam.position;
+        let (du, dv) = (self.cam.pixel_delta_u, self.cam.pixel_delta_v);
+        let direction_shift = (dv * i as f64) + (du * j as f64);
+        Ray::new(self.cam.position, default_direction - direction_shift)
+    }
+
+    fn check_hit(&self, r: &Ray) -> (bool, HitRecord) {
+        let mut record = HitRecord::default();
+        let mut hit = false;
+        let mut tmp = HitRecord::default();
+        let mut closest = Interval::new(0.001, f64::INFINITY);
+        for object in &self.objs.objects {
+            if object.hit(r, &closest, &mut tmp) == true {
+                hit = true;
+                closest.max = tmp.t;
+                record = tmp;
+            }
+        }
+        (hit, record)
+    }
+
+    fn cast_ray(&self, r: &Ray, depth: usize) -> Vec3 {
+        if depth <= 0 {
+            return Vec3::default();
+        }
+        let (hit, rec) = self.check_hit(&r);
+        if !hit {
+            return lerp(
+                &r,
+                Vec3::new(0.5, 0.7, 1.0),
+                Vec3::new(1.0, 1.0, 1.0),
+                );
+        }
+        let (mut at, mut scattered) = (Vec3::default(), Ray::default());
+        if let Some(mat) = rec.mat {
+            mat.scatter(&r, &rec, &mut at, &mut scattered);
+            let cast = self.cast_ray(&scattered, depth - 1);
+            Vec3::new(at.x * cast.x, at.y * cast.y, at.z * cast.z)
+        } else {
+            Vec3::default()
+        }
+    }
+
+    pub fn render_pixel(&self, i: usize, j: usize) -> Pixel {
+        let (samples, depth) = (self.cam.samples, self.cam.max_depth);
+        let scale = 1.0 / self.cam.samples as f64;
+        let mut color = Vec3::default();
+        for _ in 0..samples {
+            let ray = self.get_ray(i, j);
+            color += self.cast_ray(&ray, depth);
+        }
+        Pixel::from(color * scale)
+    }
+}
+
+impl Operation<(usize, usize), Pixel> for PixelRenderer {
+    fn run(&self, pixel_index: &(usize, usize)) -> Pixel {
+        let (i, j) = *pixel_index;
+        self.render_pixel(i, j)
+    }
+}
+
+impl WorkerRenderer {
+    pub fn new(
+        camera: Camera,
+        objects: ObjectList,
+        thread_count: usize,
+        batch_count: usize,
+        ) -> Self {
+        Self {
+            camera: Arc::new(camera),
+            objects: Arc::new(objects),
+            thread_count,
+            batch_count,
+        }
+    }
+
+    pub fn render(&self) -> Image {
+        let (w, h) = (self.camera.image_width, self.camera.image_height);
+        let renderer = PixelRenderer::new(&self.objects, &self.camera);
+        let rendering = Arc::new(renderer);
+        let runtime = Runtime::new(self.thread_count, rendering);
+        let mut indexes = Vec::with_capacity(w * h);
+        for i in 0..w {
+            for j in 0..h {
+                let idx = (i, j);
+                indexes.push(idx);
+            }
+        }
+        runtime.execute(indexes, self.batch_count);
+        let mut result = Image::new(w, h);
+        result.data = runtime.join(self.batch_count);
+        result
+    }
 }
 
 impl Renderer {
@@ -47,11 +172,6 @@ impl Renderer {
         }
         result
     }
-}
-
-struct ChunkRenderer {
-    objs: Arc<ObjectList>,
-    cam: Arc<Camera>,
 }
 
 impl ChunkRenderer {

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -46,7 +46,7 @@ impl PixelRenderer {
         let default_direction = self.cam.pixel_origin - self.cam.position;
         let (du, dv) = (self.cam.pixel_delta_u, self.cam.pixel_delta_v);
         let direction_shift = (dv * i as f64) + (du * j as f64);
-        Ray::new(self.cam.position, default_direction - direction_shift)
+        Ray::new(self.cam.position, default_direction + direction_shift)
     }
 
     fn check_hit(&self, r: &Ray) -> (bool, HitRecord) {

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::thread;
 
 use crate::materials::Scatter;
 use crate::math::*;
@@ -15,23 +14,46 @@ pub struct Renderer {
     camera: Arc<Camera>,
     objects: Arc<ObjectList>,
     thread_count: usize,
-}
-
-pub struct ChunkRenderer {
-    objs: Arc<ObjectList>,
-    cam: Arc<Camera>,
-}
-
-pub struct PixelRenderer {
-    objs: Arc<ObjectList>,
-    cam: Arc<Camera>,
-}
-
-pub struct WorkerRenderer {
-    camera: Arc<Camera>,
-    objects: Arc<ObjectList>,
-    thread_count: usize,
     batch_count: usize,
+}
+
+struct PixelRenderer {
+    objs: Arc<ObjectList>,
+    cam: Arc<Camera>,
+}
+
+impl Renderer {
+    pub fn new(
+        camera: Camera,
+        objects: ObjectList,
+        thread_count: usize,
+        batch_count: usize,
+        ) -> Self {
+        Self {
+            camera: Arc::new(camera),
+            objects: Arc::new(objects),
+            thread_count,
+            batch_count,
+        }
+    }
+
+    pub fn render(&self) -> Image {
+        let (w, h) = (self.camera.image_width, self.camera.image_height);
+        let renderer = PixelRenderer::new(&self.objects, &self.camera);
+        let rendering = Arc::new(renderer);
+        let manager = Manager::new(self.thread_count, rendering);
+        let mut indexes = Vec::with_capacity(w * h);
+        for i in 0..h {
+            for j in 0..w {
+                let idx = (i, j);
+                indexes.push(idx);
+            }
+        }
+        manager.execute(indexes, self.batch_count);
+        let mut result = Image::new(w, h);
+        result.data = manager.join(self.batch_count);
+        result
+    }
 }
 
 impl PixelRenderer {
@@ -105,178 +127,3 @@ impl Job<(usize, usize), Pixel> for PixelRenderer {
     }
 }
 
-impl WorkerRenderer {
-    pub fn new(
-        camera: Camera,
-        objects: ObjectList,
-        thread_count: usize,
-        batch_count: usize,
-        ) -> Self {
-        Self {
-            camera: Arc::new(camera),
-            objects: Arc::new(objects),
-            thread_count,
-            batch_count,
-        }
-    }
-
-    pub fn render(&self) -> Image {
-        let (w, h) = (self.camera.image_width, self.camera.image_height);
-        let renderer = PixelRenderer::new(&self.objects, &self.camera);
-        let rendering = Arc::new(renderer);
-        let manager = Manager::new(self.thread_count, rendering);
-        let mut indexes = Vec::with_capacity(w * h);
-        for i in 0..h {
-            for j in 0..w {
-                let idx = (i, j);
-                indexes.push(idx);
-            }
-        }
-        manager.execute(indexes, self.batch_count);
-        let mut result = Image::new(w, h);
-        result.data = manager.join(self.batch_count);
-        result
-    }
-}
-
-impl Renderer {
-    pub fn new(
-        camera: Camera,
-        objects: ObjectList,
-        thread_count: usize,
-    ) -> Self {
-        Self {
-            camera: Arc::new(camera),
-            objects: Arc::new(objects),
-            thread_count,
-        }
-    }
-
-    pub fn render(&self) -> Image {
-        let (w, h) = (self.camera.image_width, self.camera.image_height);
-        let (chunk_rows, chunk_cols) = (h / self.thread_count, w);
-        let handles = (0..self.thread_count).map(|n| {
-            let renderer = ChunkRenderer::new(&self.objects, &self.camera);
-            let (start_row, end_row) = (n * chunk_rows, (n + 1) * chunk_rows);
-            let (start_col, end_col) = (0, chunk_cols);
-            thread::spawn(move || {
-                renderer.render_chunk(start_row, end_row, start_col, end_col)
-            })
-        });
-        let mut result = Image::new(w, h);
-        for handle in handles {
-            let pixels = handle.join().unwrap();
-            for pixel in pixels {
-                result.data.push(pixel);
-            }
-        }
-        result
-    }
-}
-
-impl ChunkRenderer {
-    pub fn new(objects: &Arc<ObjectList>, camera: &Arc<Camera>) -> Self {
-        Self {
-            objs: Arc::clone(objects),
-            cam: Arc::clone(camera),
-        }
-    }
-
-    fn get_rays(
-        &self,
-        row_start: usize,
-        row_end: usize,
-        col_start: usize,
-        col_end: usize,
-        rays: &mut [Ray],
-    ) {
-        let default_direction = self.cam.pixel_origin - self.cam.position;
-        let (du, dv) = (self.cam.pixel_delta_u, self.cam.pixel_delta_v);
-        for row in row_start..row_end {
-            for col in col_start..col_end {
-                let idx = (row - row_start) * (col_end - col_start) + col;
-                let direction_shift = (dv * row as f64) + (du * col as f64);
-                rays[idx].direction = default_direction + direction_shift;
-            }
-        }
-    }
-
-    fn check_hit(&self, r: &Ray) -> (bool, HitRecord) {
-        let mut record = HitRecord::default();
-        let mut hit = false;
-        let mut tmp = HitRecord::default();
-        let mut closest = Interval::new(0.001, f64::INFINITY);
-        for object in &self.objs.objects {
-            if object.hit(r, &closest, &mut tmp) == true {
-                hit = true;
-                closest.max = tmp.t;
-                record = tmp;
-            }
-        }
-        (hit, record)
-    }
-
-    fn cast_ray(&self, r: &Ray, depth: usize) -> Vec3 {
-        if depth <= 0 {
-            return Vec3::default();
-        }
-        let (hit, rec) = self.check_hit(&r);
-        if !hit {
-            return lerp(
-                &r,
-                Vec3::new(0.5, 0.7, 1.0),
-                Vec3::new(1.0, 1.0, 1.0),
-            );
-        }
-        let (mut at, mut scattered) = (Vec3::default(), Ray::default());
-        if let Some(mat) = rec.mat {
-            mat.scatter(&r, &rec, &mut at, &mut scattered);
-            let cast = self.cast_ray(&scattered, depth - 1);
-            Vec3::new(at.x * cast.x, at.y * cast.y, at.z * cast.z)
-        } else {
-            Vec3::default()
-        }
-    }
-
-    fn cast_rays(&self, rays: &[Ray], colors: &mut [Vec3], max_depth: usize) {
-        let pixel_count = rays.len();
-        for i in 0..pixel_count {
-            colors[i] += self.cast_ray(&rays[i], max_depth);
-        }
-    }
-
-    pub fn render_chunk(
-        &self,
-        row_start: usize,
-        row_end: usize,
-        col_start: usize,
-        col_end: usize,
-    ) -> Vec<Pixel> {
-        let (samples, depth) = (self.cam.samples, self.cam.max_depth);
-        let scale = 1.0 / self.cam.samples as f64;
-        let position = self.cam.position;
-        let pixel_count = (row_end - row_start) * (col_end - col_start);
-        let mut colors = vec![Vec3::default(); pixel_count];
-        let mut rays = vec![Ray::new(position, Vec3::default()); pixel_count];
-
-        for _ in 0..samples {
-            self.get_rays(
-                row_start,
-                row_end,
-                col_start,
-                col_end,
-                &mut rays[..],
-            );
-            self.cast_rays(&rays[..], &mut colors[..], depth);
-        }
-
-        for i in 0..pixel_count {
-            colors[i] *= scale;
-        }
-
-        colors
-            .into_iter()
-            .map(|c| Pixel::from(c))
-            .collect::<Vec<_>>()
-    }
-}

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -126,8 +126,8 @@ impl WorkerRenderer {
         let rendering = Arc::new(renderer);
         let runtime = Runtime::new(self.thread_count, rendering);
         let mut indexes = Vec::with_capacity(w * h);
-        for i in 0..w {
-            for j in 0..h {
+        for i in 0..h {
+            for j in 0..w {
                 let idx = (i, j);
                 indexes.push(idx);
             }

--- a/src/rendering/renderer.rs
+++ b/src/rendering/renderer.rs
@@ -68,12 +68,14 @@ impl ChunkRenderer {
         col_start: usize,
         col_end: usize,
     ) -> Vec<(f64, f64)> {
-        // todo - fix this function and reduce complexity
-        (row_start..row_end)
-            .flat_map(|r| {
-                (col_start..col_end).map(move |c| (r as f64, c as f64))
-            })
-            .collect::<Vec<_>>()
+        let count = (row_end - row_start) * (col_end - col_start);
+        let mut indicies: Vec<(f64, f64)> = Vec::with_capacity(count);
+        for row in row_start..row_end {
+            for col in col_start..col_end {
+                indicies.push((row as f64, col as f64)); 
+            }
+        }
+        indicies
     }
     
     // the indicies function is probably an unnecessary perf cost.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,0 +1,5 @@
+// modules
+pub mod runtime;
+
+// flatten
+pub use runtime::*;

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -20,6 +20,14 @@ pub struct Worker<T, U> {
     output: Sender<Batch<U>>,
 }
 
+//Update the worker status enum and Batch type to be one thing.
+//Workers will have a Work::Awaiting or Work::Working(Batch<T>) 
+//When workers have a Work::Awaiting, they will do nothing
+//When workers have a Work::Working(Batch<T>), they will work on
+//the batch until it is complete. Then they will set their own status to
+//Work::Awaiting
+
+
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum WorkerStatus {
     HasWork,

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -1,0 +1,56 @@
+use std::sync::mpsc::{channel, Sender, Receiver};
+use std::sync::Arc;
+use std::thread;
+
+pub struct Runtime<T, U> {
+    workers: Vec<Worker<T, U>>,
+    handles: Vec<Sender<T>>, 
+    collector: Receiver<U>,
+}
+
+trait Operation<T, U> {
+    fn run(&self, input: T) -> U;
+}
+
+pub struct Worker<T, U> {
+    job: Arc<dyn Operation<T, U>>,
+    incoming: Receiver<T>,    
+    outgoing: Sender<U>,
+}
+
+impl<T, U> Worker<T, U> {
+    pub fn new(
+        job: Arc<dyn Operation<T, U>>,
+        outgoing: &Sender<U>,
+    ) -> (Self, Sender<T>) {
+        let (handle, incoming) = channel();
+        let worker = Self {
+            job,
+            incoming,
+            outgoing: outgoing.clone(),
+        };
+        (worker, handle)
+    }
+}
+
+impl<T, U> Runtime<T, U> {
+    pub fn new(threads: usize, job: Arc<dyn Operation<T, U>>) -> Self {
+        let (worker_tx, collector) = channel();
+
+        let mut workers = Vec::with_capacity(threads);
+        let mut handles = Vec::with_capacity(threads);
+
+        for _ in 0..threads {
+            let job = job.clone();
+            let (worker, handle) = Worker::new(job, &worker_tx);
+            workers.push(worker);
+            handles.push(handle);
+        }
+
+        Self {
+            workers,
+            handles,
+            collector,
+        }
+    }
+}

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -19,6 +19,7 @@ pub struct Worker<T, U> {
     output: Sender<U>,
 }
 
+#[derive(Clone, Copy)]
 pub enum WorkerStatus {
     Busy,
     Free,
@@ -80,7 +81,7 @@ where
         outgoing: &Sender<U>
     ) -> Self {
         Self {
-            status: Arc::new(Mutex::New(WorkerStatus::Free)),
+            status: Arc::new(Mutex::new(WorkerStatus::Free)),
             job: Arc::clone(job),
             input: Arc::new(Mutex::new(Batch::new(0))),
             output: outgoing.clone(),
@@ -91,8 +92,9 @@ where
         Arc::clone(&self.input)
     }
 
-    pub fn status(&self) -> &WorkerStatus {
-        &self.status
+    pub fn status(&self) -> WorkerStatus {
+        let status = self.status.lock().unwrap();
+        *status
     }
 
     pub fn start(&self) {

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -49,6 +49,9 @@ pub enum DispatchResult<T> {
     AllWorkersBusy(Batch<T>),
 }
 
+// change plan - refactor batch so that cloning is not necessary,
+// prefer to pass references and pass back data
+
 impl<T> Batch<T> 
 where
     T: Clone,

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -13,7 +13,7 @@ pub struct Runtime<T, U> {
 }
 
 pub struct Worker<T, U> {
-    status: WorkerStatus,
+    status: Arc<Mutex<WorkerStatus>>,
     job: Arc<dyn Operation<T, U> + Send + Sync>,
     input: Arc<Mutex<Batch<T>>>,    
     output: Sender<U>,
@@ -80,7 +80,7 @@ where
         outgoing: &Sender<U>
     ) -> Self {
         Self {
-            status: WorkerStatus::Free,
+            status: Arc::new(Mutex::New(WorkerStatus::Free)),
             job: Arc::clone(job),
             input: Arc::new(Mutex::new(Batch::new(0))),
             output: outgoing.clone(),
@@ -96,7 +96,7 @@ where
     }
 
     pub fn start(&self) {
-        println!("worker started")
+        todo!();
     }
 }
 
@@ -155,3 +155,5 @@ where
         todo!();
     }
 }
+
+

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -175,6 +175,7 @@ where
                 DispatchResult::Dispatched => {}
                 DispatchResult::AllWorkersBusy(batch) => {
                     batches.push_back(batch);
+                    thread::sleep(std::time::Duration::from_millis(10));
                 }
             } 
         }

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -76,8 +76,8 @@ impl<T> Batcher<T> {
 
 impl<T, U> Worker<T, U>
 where
-    T: Clone + Send + Sync + 'static,
-    U: Clone + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+    U: Send + Sync + 'static,
 {
     pub fn new(
         job: &Arc<dyn Job<T, U> + Send + Sync>,
@@ -124,8 +124,8 @@ where
 
 impl<T, U> Manager<T, U>
 where
-    T: Clone + Send + Sync + 'static,
-    U: Clone + Send + Sync + 'static,
+    T: Send + Sync + 'static,
+    U: Send + Sync + 'static,
 {
     pub fn new(
         thread_count: usize,

--- a/src/runtime/runtime.rs
+++ b/src/runtime/runtime.rs
@@ -42,9 +42,6 @@ pub enum DispatchResult<T> {
     AllWorkersBusy(Batch<T>),
 }
 
-// change plan - refactor batch so that cloning is not necessary,
-// prefer to pass references and pass back data
-
 impl<T> Batch<T> {
     pub fn new(id: usize) -> Self {
         let items = Vec::new();
@@ -64,13 +61,13 @@ impl<T> Batcher<T> {
     pub fn create_batches(mut self, batch_count: usize) -> VecDeque<Batch<T>> {
         assert!(self.data.len() % batch_count == 0);
         let batch_size = self.data.len() / batch_count;
-        let mut result = VecDeque::new();
+        let mut work_batches = VecDeque::new();
         for i in 0..batch_count {
             let batch: Vec<T> = self.data.drain(..batch_size).collect();
             let batch = Batch::from_vec(i, batch);
-            result.push_back(batch);
+            work_batches.push_back(batch);
         }
-        result
+        work_batches
     }
 }
 


### PR DESCRIPTION
Created a runtime which splits work into batches and delegates them to workers, balancing the compute load between threads. Replaced the old `Renderer`, and replaced `ChunkRenderer` with `PixelRenderer`.